### PR TITLE
Dltsviewer 54 -- Rights info clipped at bottom of left metadata pane

### DIFF
--- a/css/dlts_viewer.css
+++ b/css/dlts_viewer.css
@@ -603,6 +603,11 @@ html .page {
   flex-direction: column;
 }
 
+/* line 11, ../sass/partials/book/panes/_pane-base.scss */
+html body.admin-menu {
+  height: calc(100vh - 29px) !important;
+}
+
 /* line 1, ../sass/partials/book/panes/_pane-top.scss */
 #titlebar {
   background-color: #5a1b1c;

--- a/css/dlts_viewer.css
+++ b/css/dlts_viewer.css
@@ -597,6 +597,12 @@ html body, html #main, html #page {
   box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
 }
 
+/* line 6, ../sass/partials/book/panes/_pane-base.scss */
+html .page {
+  display: flex;
+  flex-direction: column;
+}
+
 /* line 1, ../sass/partials/book/panes/_pane-top.scss */
 #titlebar {
   background-color: #5a1b1c;
@@ -612,39 +618,41 @@ html body, html #main, html #page {
   margin-left: .6rem;
 }
 
-/* line 5, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 4, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar {
   background-color: #333333;
   overflow: hidden;
-  padding: 5px 0;
+  padding: 5px 0 0;
+  flex: 0 0 55px;
+  max-width: 100vw;
 }
-/* line 9, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 10, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-left,
 #navbar .navbar-middle,
 #navbar .navbar-right,
 #navbar .navbar-arrows,
 #navbar .navbar-fullscreen {
   width: auto;
-  overflow: hidden;
+  overflow: auto;
   height: 46px;
 }
-/* line 18, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 19, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-left,
 #navbar .navbar-middle,
 #navbar .navbar-arrows {
   padding-right: 7%;
   float: left;
 }
-/* line 24, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 25, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-fullscreen {
   float: right;
+  margin-right: 20px;
 }
-/* line 27, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 29, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-fullscreen .navbar-item {
-  float: right;
-  margin: 0 0.5em 0 0;
+  float: none;
 }
-/* line 31, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 32, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item {
   min-width: 50px;
   display: block;
@@ -652,8 +660,12 @@ html body, html #main, html #page {
   margin: 0 0 0 .5em;
   font-size: 2.3em;
 }
-/* line 37, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item a, #navbar .navbar-item a.active, #navbar .navbar-item span, #navbar .navbar-item .olControlDLTSZoomInItemInactive, #navbar .navbar-item .olControlDLTSZoomOutItemInactive {
+/* line 38, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item a,
+#navbar .navbar-item a.active,
+#navbar .navbar-item span,
+#navbar .navbar-item .olControlDLTSZoomInItemInactive,
+#navbar .navbar-item .olControlDLTSZoomOutItemInactive {
   display: block;
   margin: 0 auto;
   width: 44px;
@@ -681,8 +693,16 @@ html body, html #main, html #page {
   -webkit-transition-timing-function: ease-in;
   transition-timing-function: ease-in;
 }
-/* line 51, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item a:focus, #navbar .navbar-item a:visited, #navbar .navbar-item a.active:focus, #navbar .navbar-item a.active:visited, #navbar .navbar-item span:focus, #navbar .navbar-item span:visited, #navbar .navbar-item .olControlDLTSZoomInItemInactive:focus, #navbar .navbar-item .olControlDLTSZoomInItemInactive:visited, #navbar .navbar-item .olControlDLTSZoomOutItemInactive:focus, #navbar .navbar-item .olControlDLTSZoomOutItemInactive:visited {
+/* line 56, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item a:focus, #navbar .navbar-item a:visited,
+#navbar .navbar-item a.active:focus,
+#navbar .navbar-item a.active:visited,
+#navbar .navbar-item span:focus,
+#navbar .navbar-item span:visited,
+#navbar .navbar-item .olControlDLTSZoomInItemInactive:focus,
+#navbar .navbar-item .olControlDLTSZoomInItemInactive:visited,
+#navbar .navbar-item .olControlDLTSZoomOutItemInactive:focus,
+#navbar .navbar-item .olControlDLTSZoomOutItemInactive:visited {
   text-decoration: none;
   color: #ffffff;
   opacity: 0.8;
@@ -691,8 +711,12 @@ html body, html #main, html #page {
   transition-duration: initial;
   transition-timing-function: initial;
 }
-/* line 60, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item a:hover, #navbar .navbar-item a.active:hover, #navbar .navbar-item span:hover, #navbar .navbar-item .olControlDLTSZoomInItemInactive:hover, #navbar .navbar-item .olControlDLTSZoomOutItemInactive:hover {
+/* line 66, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item a:hover,
+#navbar .navbar-item a.active:hover,
+#navbar .navbar-item span:hover,
+#navbar .navbar-item .olControlDLTSZoomInItemInactive:hover,
+#navbar .navbar-item .olControlDLTSZoomOutItemInactive:hover {
   opacity: 1;
   cursor: pointer;
   -moz-box-shadow: inset 2px 0 10px rgba(0, 0, 0, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.75), inset 2px 2px 15px #7f7f7f, 0px 1px 1px white;
@@ -701,8 +725,12 @@ html body, html #main, html #page {
   text-decoration: none;
   color: #ffffff;
 }
-/* line 67, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item a.on, #navbar .navbar-item a.active.on, #navbar .navbar-item span.on, #navbar .navbar-item .olControlDLTSZoomInItemInactive.on, #navbar .navbar-item .olControlDLTSZoomOutItemInactive.on {
+/* line 73, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item a.on,
+#navbar .navbar-item a.active.on,
+#navbar .navbar-item span.on,
+#navbar .navbar-item .olControlDLTSZoomInItemInactive.on,
+#navbar .navbar-item .olControlDLTSZoomOutItemInactive.on {
   border: none;
   opacity: 1;
   cursor: pointer;
@@ -711,8 +739,12 @@ html body, html #main, html #page {
   box-shadow: inset 2px 0 10px rgba(0, 0, 0, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.5), 0px 1px 1px rgba(255, 255, 255, 0.75), inset 2px 2px 50px rgba(0, 0, 0, 0.3);
   color: #ffffff;
 }
-/* line 74, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item a:before, #navbar .navbar-item a.active:before, #navbar .navbar-item span:before, #navbar .navbar-item .olControlDLTSZoomInItemInactive:before, #navbar .navbar-item .olControlDLTSZoomOutItemInactive:before {
+/* line 80, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item a:before,
+#navbar .navbar-item a.active:before,
+#navbar .navbar-item span:before,
+#navbar .navbar-item .olControlDLTSZoomInItemInactive:before,
+#navbar .navbar-item .olControlDLTSZoomOutItemInactive:before {
   font-family: "book-viewer";
   margin: .2em;
   line-height: 1.4em;
@@ -721,19 +753,23 @@ html body, html #main, html #page {
   speak: none;
   -webkit-font-smoothing: antialiased;
 }
-/* line 84, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item .inactive, #navbar .navbar-item .zoom_in_max, #navbar .navbar-item .zoom_out_max {
+/* line 90, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item .inactive,
+#navbar .navbar-item .zoom_in_max,
+#navbar .navbar-item .zoom_out_max {
   opacity: 0.33;
   -moz-box-shadow: none !important;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
   cursor: default !important;
 }
-/* line 88, ../sass/partials/book/panes/_pane-navbar.scss */
-#navbar .navbar-item .inactive:hover, #navbar .navbar-item .zoom_in_max:hover, #navbar .navbar-item .zoom_out_max:hover {
+/* line 96, ../sass/partials/book/panes/_pane-navbar.scss */
+#navbar .navbar-item .inactive:hover,
+#navbar .navbar-item .zoom_in_max:hover,
+#navbar .navbar-item .zoom_out_max:hover {
   opacity: 0.33 !important;
 }
-/* line 93, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 101, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item a span {
   text-indent: -119988px;
   overflow: hidden;
@@ -741,78 +777,83 @@ html body, html #main, html #page {
   text-transform: capitalize;
   display: none;
 }
-/* line 99, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 107, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .metadata:before {
   content: "\e016";
 }
-/* line 104, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 112, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .fullscreen:before {
   content: "\e006";
 }
-/* line 107, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 115, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .fullscreen.on:before {
   content: "\e005";
 }
-/* line 111, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 119, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .page-double {
   width: 62px !important;
 }
-/* line 113, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 121, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .page-double:before {
   content: "\e00a";
 }
-/* line 118, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 126, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .page-single:before {
   content: "\e009";
 }
-/* line 123, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 131, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .thumbnails:before {
   content: "\e007";
 }
-/* line 128, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 136, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .pager-right:before {
   content: "\e012";
 }
-/* line 133, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 141, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .pager-left:before {
   content: "\e013";
 }
-/* line 138, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 146, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .annotations:before {
   content: "\e004";
 }
-/* line 143, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 151, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .search:before {
   content: "\e003";
 }
-/* line 148, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 156, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .olControlDLTSZoomInItemInactive:before {
   content: "\e00b";
 }
-/* line 153, ../sass/partials/book/panes/_pane-navbar.scss */
+/* line 161, ../sass/partials/book/panes/_pane-navbar.scss */
 #navbar .navbar-item .olControlDLTSZoomOutItemInactive:before {
   content: "\e00c";
 }
 
 @media screen and (max-width: 700px) {
-  /* line 161, ../sass/partials/book/panes/_pane-navbar.scss */
-  .navbar-left, .navbar-middle, .navbar-arrows {
+  /* line 169, ../sass/partials/book/panes/_pane-navbar.scss */
+  .navbar-left,
+  .navbar-middle,
+  .navbar-arrows {
     padding: 0;
   }
 
-  /* line 164, ../sass/partials/book/panes/_pane-navbar.scss */
-  .navbar-fullscreen .navbar-item, .navbar-item {
+  /* line 174, ../sass/partials/book/panes/_pane-navbar.scss */
+  .navbar-fullscreen .navbar-item,
+  .navbar-item {
     margin: 0 .2em;
   }
 }
 @media screen and (max-width: 600px) {
-  /* line 170, ../sass/partials/book/panes/_pane-navbar.scss */
-  .navbar-fullscreen .navbar-item, .navbar-item {
+  /* line 181, ../sass/partials/book/panes/_pane-navbar.scss */
+  .navbar-fullscreen .navbar-item,
+  .navbar-item {
     margin: 0 .2em;
   }
 
-  /* line 173, ../sass/partials/book/panes/_pane-navbar.scss */
-  .navbar-middle, .navbar-arrows {
+  /* line 185, ../sass/partials/book/panes/_pane-navbar.scss */
+  .navbar-middle,
+  .navbar-arrows {
     display: none;
   }
 }
@@ -1106,17 +1147,18 @@ body .pane.main[dir="rtl"] .pane.display .paging.pager-left {
   text-align: left;
 }
 
-/* line 3, ../sass/partials/book/panes/_pane-slider.scss */
-.yui3-skin-sam .yui3-slider-x .yui3-slider-rail, .yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-left, .yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-right {
+/* line 2, ../sass/partials/book/panes/_pane-slider.scss */
+.yui3-skin-sam .yui3-slider-x .yui3-slider-rail,
+.yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-left,
+.yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-right {
   background-image: url(../images/slider/rail-x.png) !important;
 }
 
-/* line 7, ../sass/partials/book/panes/_pane-slider.scss */
+/* line 8, ../sass/partials/book/panes/_pane-slider.scss */
 #pager {
   width: 100%;
-  position: fixed;
-  bottom: 0;
-  z-index: 999999;
+  flex: 0 0 40px;
+  height: 40px;
   background-color: #e5e5e5;
   background: #e5e5e5;
   background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2VkZWRlZCIgc3RvcC1vcGFjaXR5PSIwLjUiLz48c3RvcCBvZmZzZXQ9IjE1JSIgc3RvcC1jb2xvcj0iI2U1ZTVlNSIgc3RvcC1vcGFjaXR5PSIwLjAiLz48c3RvcCBvZmZzZXQ9IjkyJSIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjAiLz48c3RvcCBvZmZzZXQ9IjExMCUiIHN0b3AtY29sb3I9IiMwMDAwMDAiIHN0b3Atb3BhY2l0eT0iMC41Ii8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
@@ -1138,7 +1180,7 @@ body .pane.main[dir="rtl"] .pane.display .paging.pager-left {
   text-align: center;
   padding: 0;
   border: 1px solid;
-  border-color: #aaa  #fff #fff #aaa;
+  border-color: #aaa #fff #fff #aaa;
   -moz-border-radius: 3px;
   -webkit-border-radius: 3px;
   border-radius: 3px;
@@ -1151,29 +1193,30 @@ body .pane.main[dir="rtl"] .pane.display .paging.pager-left {
   display: inline;
 }
 /* line 34, ../sass/partials/book/panes/_pane-slider.scss */
-#pager form + span, #pager form + span + span {
+#pager form + span,
+#pager form + span + span {
   text-shadow: embossed-text-shadow;
   font-weight: bold;
   color: #444;
 }
-/* line 39, ../sass/partials/book/panes/_pane-slider.scss */
+/* line 40, ../sass/partials/book/panes/_pane-slider.scss */
 #pager #slider {
   padding: 0px 20px;
 }
-/* line 42, ../sass/partials/book/panes/_pane-slider.scss */
+/* line 43, ../sass/partials/book/panes/_pane-slider.scss */
 #pager .pages_count_total {
   white-space: nowrap;
   color: #777;
   cursor: default;
 }
-/* line 48, ../sass/partials/book/panes/_pane-slider.scss */
+/* line 49, ../sass/partials/book/panes/_pane-slider.scss */
 #pager #slider_value.error {
   border: 1px solid #8C2E0B;
   background-color: #DF3A01;
   opacity: 1;
   color: #fff !important;
 }
-/* line 54, ../sass/partials/book/panes/_pane-slider.scss */
+/* line 55, ../sass/partials/book/panes/_pane-slider.scss */
 #pager #slider_value.warning {
   border: 1px solid #FEFFBF;
   background-color: #B2B300;
@@ -1357,9 +1400,8 @@ body.openlayers-loading .olLayerDiv {
 /* line 14, ../sass/partials/book/panes/_pane-pager.scss */
 .pager {
   background: #666666;
-  display: inline;
 }
-/* line 17, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 16, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li {
   display: inline;
   float: left;
@@ -1368,7 +1410,7 @@ body.openlayers-loading .olLayerDiv {
   min-width: 48px;
   opacity: 0.8;
 }
-/* line 24, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 23, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-current, .pager li.pager-ellipsis {
   float: left;
   display: block;
@@ -1379,7 +1421,7 @@ body.openlayers-loading .olLayerDiv {
   border: none;
   line-height: 2em;
 }
-/* line 35, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 34, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li a {
   display: block;
   text-align: center;
@@ -1391,12 +1433,12 @@ body.openlayers-loading .olLayerDiv {
   border: none;
   opacity: 0.8;
 }
-/* line 45, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 44, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li a:hover {
   opacity: 1;
   text-decoration: none;
 }
-/* line 49, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 48, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li a:before {
   font-family: "book-viewer";
   margin: 0 99em 0 .2em;
@@ -1407,47 +1449,47 @@ body.openlayers-loading .olLayerDiv {
   speak: none;
   -webkit-font-smoothing: antialiased;
 }
-/* line 60, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 59, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.close a {
   overflow: hidden;
 }
-/* line 62, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 61, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.close a:before {
   content: "\e000";
   color: #ffffff;
 }
-/* line 67, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 66, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-previous a {
   overflow: hidden;
 }
-/* line 69, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 68, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-previous a:before {
   content: "\e013";
   color: #ffffff;
 }
-/* line 74, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 73, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-next a {
   overflow: hidden;
 }
-/* line 76, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 75, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-next a:before {
   content: "\e012";
   color: #ffffff;
 }
-/* line 81, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 80, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-first a {
   overflow: hidden;
 }
-/* line 83, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 82, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-first a:before {
   content: "\e010";
   color: #ffffff;
 }
-/* line 88, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 87, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-last a {
   overflow: hidden;
 }
-/* line 90, ../sass/partials/book/panes/_pane-pager.scss */
+/* line 89, ../sass/partials/book/panes/_pane-pager.scss */
 .pager li.pager-last a:before {
   content: "\e011";
   color: #ffffff;

--- a/js/ui.components.yui.js
+++ b/js/ui.components.yui.js
@@ -37,25 +37,7 @@ YUI().use(
     length:(Y.one('#pager').get('offsetWidth') - 120) + 'px' 
   });
   /** nodes */
-    function resizePageMeta() {
-      slider.set('length' ,(Y.one('#pager').get('offsetWidth') - 120 ));
-       var viewportHeight = this.get('winHeight'),
-        adminBarHeight = 0,
-        // topHeight = Y.one('#top').get('offsetHeight'),
-        navbarHeight = Y.one('#navbar').get('offsetHeight'),
-        pageHeight = Y.one('#pager').get('offsetHeight'),
-        nodeAdminMenu = Y.one('#admin-menu'),
-        sidebarHeight
-      ; /** definition list end */
-      if (nodeAdminMenu) {
-        adminBarHeight =  nodeAdminMenu.get('offsetHeight') ;
-      }
-      //sidebarHeight = viewportHeight - (adminBarHeight + topHeight + navbarHeight + pageHeight);
-      sidebarHeight = viewportHeight - (adminBarHeight + navbarHeight + pageHeight);
-      Y.one('#pagemeta').setStyles({
-        'height': sidebarHeight
-      });
-    }
+    
     function on_toggle_language(e) {
       var current_target = e.currentTarget;
       var data_target = current_target.get('value');
@@ -547,10 +529,6 @@ YUI().use(
     Y.on('button:button-fullscreen:off', fullscreenOff);
 
     Y.once('contentready', openLayersTilesLoading, '.dlts_viewer_map');
-
-    Y.on('contentready', resizePageMeta, '#pagemeta');
-
-    Y.on('windowresize', resizePageMeta);
 
     /** Thumbnails related events */
     Y.on('button:button-thumbnails:on', onButtonThumbnailsOn);

--- a/sass/partials/book/panes/_pane-base.scss
+++ b/sass/partials/book/panes/_pane-base.scss
@@ -7,3 +7,9 @@ html .page {
   display: flex;
   flex-direction: column;
 }
+
+html body.admin-menu  {
+	// 29px is a number hard-coded by Drupal;
+  height: calc(100vh - 29px) !important;
+}
+

--- a/sass/partials/book/panes/_pane-base.scss
+++ b/sass/partials/book/panes/_pane-base.scss
@@ -2,3 +2,8 @@
   background-color: $pane-background;
   @include bv-box-shadow($pane-box-shadow);
 }
+
+html .page {
+  display: flex;
+  flex-direction: column;
+}

--- a/sass/partials/book/panes/_pane-navbar.scss
+++ b/sass/partials/book/panes/_pane-navbar.scss
@@ -1,18 +1,19 @@
 $break-small: 600px;
 $break-medium: 700px;
 $break-large: 1200px;
-
 #navbar {
   background-color: $navbar-overlay;
   overflow: hidden;
-  padding: 5px 0;
+  padding: 5px 0 0;
+  flex: 0 0 55px;
+  max-width: 100vw;
   .navbar-left,
   .navbar-middle,
   .navbar-right,
   .navbar-arrows,
   .navbar-fullscreen {
     width: auto;
-    overflow: hidden;
+    overflow: auto;
     height: 46px;
   }
   .navbar-left,
@@ -23,10 +24,10 @@ $break-large: 1200px;
   }
   .navbar-fullscreen {
     float: right;
+    margin-right: 20px;
   }
   .navbar-fullscreen .navbar-item {
-    float: right;
-    margin: 0 0.5em 0 0;
+    float: none;
   }
   .navbar-item {
     min-width: 50px;
@@ -34,7 +35,11 @@ $break-large: 1200px;
     float: left;
     margin: 0 0 0 .5em;
     font-size: 2.3em;
-    a, a.active, span, .olControlDLTSZoomInItemInactive, .olControlDLTSZoomOutItemInactive {
+    a,
+    a.active,
+    span,
+    .olControlDLTSZoomInItemInactive,
+    .olControlDLTSZoomOutItemInactive {
       display: block;
       margin: 0 auto;
       width: 44px;
@@ -48,7 +53,8 @@ $break-large: 1200px;
       @include transition-property((border, box-shadow));
       @include transition-duration(100ms);
       @include transition-timing-function(ease-in);
-      &:focus, &:visited {
+      &:focus,
+      &:visited {
         text-decoration: none;
         color: $navbar-icon-color;
         opacity: $normal-opacity;
@@ -81,7 +87,9 @@ $break-large: 1200px;
         -webkit-font-smoothing: antialiased;
       }
     }
-    .inactive, .zoom_in_max, .zoom_out_max {
+    .inactive,
+    .zoom_in_max,
+    .zoom_out_max {
       opacity: $dimmed-opacity;
       @include box-shadow(none !important);
       cursor: default !important;
@@ -158,19 +166,24 @@ $break-large: 1200px;
 }
 
 @media screen and (max-width: $break-medium) {
-  .navbar-left, .navbar-middle, .navbar-arrows {
+  .navbar-left,
+  .navbar-middle,
+  .navbar-arrows {
     padding: 0;
   }
-  .navbar-fullscreen .navbar-item, .navbar-item {
+  .navbar-fullscreen .navbar-item,
+  .navbar-item {
     margin: 0 .2em;
   }
 }
 
 @media screen and (max-width: $break-small) {
-  .navbar-fullscreen .navbar-item, .navbar-item {
+  .navbar-fullscreen .navbar-item,
+  .navbar-item {
     margin: 0 .2em;
   }
-  .navbar-middle, .navbar-arrows {
+  .navbar-middle,
+  .navbar-arrows {
     display: none;
   }
 }

--- a/sass/partials/book/panes/_pane-pager.scss
+++ b/sass/partials/book/panes/_pane-pager.scss
@@ -13,7 +13,6 @@
 
 .pager {
   background: $dark-background;
-  display: inline;
   li {
     display: inline;
     float: left;

--- a/sass/partials/book/panes/_pane-slider.scss
+++ b/sass/partials/book/panes/_pane-slider.scss
@@ -1,14 +1,14 @@
 // YUI Slider see http://yuilibrary.com/yui/docs/slider/
-
-.yui3-skin-sam .yui3-slider-x .yui3-slider-rail, .yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-left, .yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-right {
+.yui3-skin-sam .yui3-slider-x .yui3-slider-rail,
+.yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-left,
+.yui3-skin-sam .yui3-slider-x .yui3-slider-rail-cap-right {
   background-image: url(../images/slider/rail-x.png) !important;
 }
 
 #pager {
   width: 100%;
-  position: fixed;
-  bottom: 0;
-  z-index: 999999;
+  flex: 0 0 40px;
+  height:40px;
   background-color: $light-background;
   @include embossed-gradient($slider-overlay, $slider-topbackground, $slider-bottombackground);
   color: #333;
@@ -22,7 +22,7 @@
     text-align: center;
     padding: 0;
     border: 1px solid;
-    border-color: #aaa  #fff #fff #aaa;
+    border-color: #aaa #fff #fff #aaa;
     @include border-radius(3px);
     cursor: text;
     color: #444;
@@ -31,7 +31,8 @@
   form {
     display: inline;
   }
-  form + span, form + span + span {
+  form + span,
+  form + span + span {
     @include bv-text-shadow(embossed-text-shadow);
     font-weight: bold;
     color: #444;


### PR DESCRIPTION
Using flexbox instead of absolute positioning for left metadata  panel
This allows us to remove the javascript function that used to resize this panel
